### PR TITLE
Use AWS attribution for credentials provider

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -335,3 +335,13 @@ This product includes code from Apache Flink.
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://flink.apache.org/
 License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from AWS SDK for Java 2.0.
+
+* Copy of org.apache.iceberg.aws.StaticCredentialsProvider.java with a new factory method
+
+Copyright: Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved
+Home page: https://github.com/aws/aws-sdk-java-v2
+License: http://aws.amazon.com/apache2.0

--- a/NOTICE
+++ b/NOTICE
@@ -24,3 +24,21 @@ the following copyright notice:
 | See the License for the specific language governing permissions and
 | limitations under the License.
 
+
+--------------------------------------------------------------------------------
+
+This project includes code from Amazon.com, Inc. with the following copyright
+notice:
+
+| Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+|
+| Licensed under the Apache License, Version 2.0 (the "License").
+| You may not use this file except in compliance with the License.
+| A copy of the License is located at
+|
+|  http://aws.amazon.com/apache2.0
+|
+| or in the "license" file accompanying this file. This file is distributed
+| on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+| express or implied. See the License for the specific language governing
+| permissions and limitations under the License.

--- a/aws/src/main/java/org/apache/iceberg/aws/StaticCredentialsProvider.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/StaticCredentialsProvider.java
@@ -1,26 +1,24 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.aws;
 
+import java.util.Map;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
@@ -28,49 +26,52 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.utils.ToString;
 import software.amazon.awssdk.utils.Validate;
-import java.util.Map;
 
 /**
- * An implementation of {@link AwsCredentialsProvider} that returns a set implementation of {@link AwsCredentials}.
+ * An implementation of {@link AwsCredentialsProvider} that returns a set implementation of {@link
+ * AwsCredentials}.
+ *
+ * <p>This code was copied from the original to add the create() factory method required by Iceberg.
+ *
+ * @link <a
+ *     href="https://github.com/aws/aws-sdk-java-v2/blob/master/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/StaticCredentialsProvider.java">StaticCredentialsProvider.java</a>
  */
 @SdkPublicApi
 public final class StaticCredentialsProvider implements AwsCredentialsProvider {
-    private static final String PROVIDER_NAME = "StaticCredentialsProvider";
-    private static final String ACCESS_KEY_ID = "access-key-id";
-    private static final String SECRET_ACCESS_KEY = "secret-access-key";
-    private final AwsCredentials credentials;
+  private static final String PROVIDER_NAME = "StaticCredentialsProvider";
+  private static final String ACCESS_KEY_ID = "access-key-id";
+  private static final String SECRET_ACCESS_KEY = "secret-access-key";
+  private final AwsCredentials credentials;
 
-    private StaticCredentialsProvider(AwsCredentials credentials) {
-        Validate.notNull(credentials, "Credentials must not be null.");
-        this.credentials = withProviderName(credentials);
-    }
+  private StaticCredentialsProvider(AwsCredentials credentials) {
+    Validate.notNull(credentials, "Credentials must not be null.");
+    this.credentials = withProviderName(credentials);
+  }
 
-    private AwsCredentials withProviderName(AwsCredentials credentials) {
-        if (credentials instanceof AwsBasicCredentials) {
-            return ((AwsBasicCredentials) credentials).copy(c -> c.providerName(PROVIDER_NAME));
-        }
-        if (credentials instanceof AwsSessionCredentials) {
-            return ((AwsSessionCredentials) credentials).copy(c -> c.providerName(PROVIDER_NAME));
-        }
-        return credentials;
+  private AwsCredentials withProviderName(AwsCredentials credentials) {
+    if (credentials instanceof AwsBasicCredentials) {
+      return ((AwsBasicCredentials) credentials).copy(c -> c.providerName(PROVIDER_NAME));
     }
+    if (credentials instanceof AwsSessionCredentials) {
+      return ((AwsSessionCredentials) credentials).copy(c -> c.providerName(PROVIDER_NAME));
+    }
+    return credentials;
+  }
 
-    /**
-     * Create a credentials provider that always returns the provided set of credentials.
-     */
-    public static StaticCredentialsProvider create(Map<String, String> credentials) {
-        return new StaticCredentialsProvider(AwsBasicCredentials.create(credentials.get(ACCESS_KEY_ID), credentials.get(SECRET_ACCESS_KEY)));
-    }
+  /** Create a credentials provider that always returns the provided set of credentials. */
+  public static StaticCredentialsProvider create(Map<String, String> credentials) {
+    return new StaticCredentialsProvider(
+        AwsBasicCredentials.create(
+            credentials.get(ACCESS_KEY_ID), credentials.get(SECRET_ACCESS_KEY)));
+  }
 
-    @Override
-    public AwsCredentials resolveCredentials() {
-        return credentials;
-    }
+  @Override
+  public AwsCredentials resolveCredentials() {
+    return credentials;
+  }
 
-    @Override
-    public String toString() {
-        return ToString.builder(PROVIDER_NAME)
-                .add("credentials", credentials)
-                .build();
-    }
+  @Override
+  public String toString() {
+    return ToString.builder(PROVIDER_NAME).add("credentials", credentials).build();
+  }
 }


### PR DESCRIPTION
If we're copying ASL2 licenced code from Amazon, we should apply correct attribution: https://www.apache.org/legal/src-headers.html#header-existingcopyright, especially if we plan to contribute this upstream.