### PR TITLE
AWS: use aws client region for StsClient if available

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -159,6 +159,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   private StsClient sts() {
     return StsClient.builder()
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+        .applyMutation(awsClientProperties::applyClientRegionConfiguration)
         .build();
   }
 


### PR DESCRIPTION
make StsClient pick up region from client config so we don't rely on AWS_REGION env variable